### PR TITLE
[WIP] Docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.7-buster
+WORKDIR /workspace
+COPY . /workspace
+RUN pip install mkl
+RUN python setup.py install
+CMD ls

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# Neural description generator
+
+## Docker run
+
+```bash
+docker build -t ndg:latest .
+docker run ndg
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,9 +10,6 @@ jedi==0.15.2
 joblib==0.14.1
 jupyter-client==5.3.4
 jupyter-core==4.6.1
-mkl-fft==1.0.15
-mkl-random==1.1.0
-mkl-service==2.3.0
 munch==2.5.0
 numpy==1.18.1
 opencv-python==4.1.2.30


### PR DESCRIPTION
@Ayatafoy Hi
For some reason, I couldn't find the following dependencies:
```
mkl-fft==1.0.15	
mkl-random==1.1.0	
mkl-service==2.3.0
```
After some research, I figured out that they can only be available when using `conda`.
So, does it make sense to change the base docker image to, say, https://hub.docker.com/r/continuumio/miniconda3 in order to fix it?
And do we really need `mkl-*` dependencies in our project?